### PR TITLE
fix: fail to populate root while installing helm from ArgoCD ( Warning: RepeatedResourceWarning )

### DIFF
--- a/charts/rosette-server/templates/hooks/postinstall-upgrade-roots-hook.yaml
+++ b/charts/rosette-server/templates/hooks/postinstall-upgrade-roots-hook.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-populate-roots
+  name: {{ .Release.Name }}-upgrade-populate-roots
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
@@ -10,7 +10,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: {{ .Release.Name }}-populate-roots
+      name: {{ .Release.Name }}-upgrade-populate-roots
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/rosette-server/templates/hooks/postinstall-upgrade-roots-hook.yaml
+++ b/charts/rosette-server/templates/hooks/postinstall-upgrade-roots-hook.yaml
@@ -3,14 +3,16 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ .Release.Name }}-upgrade-populate-roots
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
-    "helm.sh/hook-weight": "0"
+  {{- if .Values.rootsInit.installJobAnnotations }}
+  annotations: {{- toYaml .Values.rootsInit.installJobAnnotations | nindent 4 }}
+  {{- end }}
 spec:
   template:
     metadata:
       name: {{ .Release.Name }}-upgrade-populate-roots
+      {{- if .Values.rootsInit.podAnnotations }}
+      annotations: {{- toYaml .Values.rootsInit.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/rosette-server/templates/hooks/postrollback-roots-hook.yaml
+++ b/charts/rosette-server/templates/hooks/postrollback-roots-hook.yaml
@@ -3,14 +3,16 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ .Release.Name }}-populate-roots
-  annotations:
-    "helm.sh/hook": post-rollback
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
-    "helm.sh/hook-weight": "0"
+  {{- if .Values.rootsInit.rollbackJobAnnotations }}
+  annotations: {{- toYaml .Values.rootsInit.rollbackJobAnnotations | nindent 4 }}
+  {{- end }}
 spec:
   template:
     metadata:
       name: {{ .Release.Name }}-populate-roots
+      {{- if .Values.rootsInit.podAnnotations }}
+      annotations: {{- toYaml .Values.rootsInit.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/rosette-server/values.yaml
+++ b/charts/rosette-server/values.yaml
@@ -121,6 +121,17 @@ volumePermissions:
 # There are certain configuration settings that are set within an endpoint's data model directories, as opposed to the regular configuration directory.
 # If you modify those settings and would like the changes to be carried through the helm upgrade/rollback process, you'll use this block to do so.
 # For more details check the documentation and see the section in the README titled "Root configurations overrides."
+rootsInit:
+  installJobAnnotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-weight": "0"
+  rollbackJobAnnotations:
+    "helm.sh/hook": post-rollback
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-weight": "0"
+  podAnnotations: {}
+
 rootsOverride:
   enabled: "false"
   overrideVolumeClaimName: ""


### PR DESCRIPTION
- Error/Warning details: Resource batch/Job/rosette v2/rosette-server-populate-roots appeared 2 times among application resources, because of the same name in both the Job resource names.
- Job doesn't start in argo due to the hard-coded Job annotations. because Argo doesn't `helm install upgrade` it does `helm template` >> `k apply -f` which doesn't create any helm hook events to trigger Jobs.
- Reproduce: Install using Argocd