### PR TITLE
BUGFIX: Fallback to default storageclass when storageclass not provided

### DIFF
--- a/charts/rosette-server/templates/pvc-roots.yaml
+++ b/charts/rosette-server/templates/pvc-roots.yaml
@@ -10,7 +10,7 @@ spec:
     matchLabels:
       {{- include "rosette-server.selectorLabels" . | nindent 6 }}
 {{- end }}
-{{- if not ( quote .Values.storageClassName | empty) }}
+{{- if .Values.storageClassName }}
   storageClassName: {{ .Values.storageClassName | quote }}
 {{- end }}
 {{- if not ( .Values.rootsVolumeName | empty) }}


### PR DESCRIPTION
This change addresses a bug where the PVC creation fails if `storageClassName `is not specified in `values.yaml.` The issue arises because the templating does not properly fallback to the default `storageClassName`.

The proposed fix ensures that when `storageClassName `is not provided, the templating correctly defaults to the specified fallback `storageClassName`, resolving the issue.